### PR TITLE
only load classification structure

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -43,7 +43,8 @@ def validate_classification():
         return False
 
     #m = sio.loadmat(config["classification"], squeeze_me=True)
-    m = hdf5storage.loadmat(config["classification"])
+    m = hdf5storage.loadmat(config["classification"],variable_names="classification")
+                
     if "classification" not in m:
         results["errors"].append("no classification object inside classification.mat");
         return False


### PR DESCRIPTION
Currently, line 46 loads all of the fields inside the "classification.mat" structure. Sometimes, there are other fields in that structure other than just "classification". For example, fg_classified structures used to be stored as a field in the .mat file.

I've updated line 46 to only load the "classification" structure. I believe the error check will still work properly if the classification field is not present. 'm' just becomes an empty structure.